### PR TITLE
modify infinity, utils and vector3d

### DIFF
--- a/code/HyperbolicModels/app.config
+++ b/code/HyperbolicModels/app.config
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/code/R3/R3.Core/Geometry/Vector3D.cs
+++ b/code/R3/R3.Core/Geometry/Vector3D.cs
@@ -133,10 +133,6 @@
 
 		public bool Compare( Vector3D other, double threshold )
 		{
-			// NOTE: This is here because when the vector is infinite, it fails the tolerance checks below.
-			if( ( X == other.X ) && ( Y == other.Y ) && ( Z == other.Z ) && W == other.W )
-				return true;
-
 			if( this.DNE && other.DNE )
 				return true;
 

--- a/code/R3/R3.Core/Math/Infinity.cs
+++ b/code/R3/R3.Core/Math/Infinity.cs
@@ -13,15 +13,18 @@
 		public const double FiniteScale = 10000;
 		public const double InfiniteScale = 500000;
 
+		public static bool IsFinite( double input )
+		{
+			return ( -InfiniteScale <= input ) && ( input <= InfiniteScale );
+		}
+
 		public static bool IsInfinite( Vector3D input )
 		{
-			// XXX - ugly hack I'd like to improve.
-			return 
-				IsInfinite( input.X ) ||
-				IsInfinite( input.Y ) ||
-				IsInfinite( input.Z ) ||
-				IsInfinite( input.W ) ||
-				input.Abs() > InfiniteScale;
+			return
+				!(IsFinite (input.X) &&
+				  IsFinite (input.Y) &&
+			      IsFinite (input.Z) &&
+			      IsFinite (input.W));
 		}
 
 		public static bool IsInfinite( Complex input )
@@ -33,10 +36,7 @@
 
 		public static bool IsInfinite( double input )
 		{
-			return
-				double.IsNaN( input ) ||
-				double.IsInfinity( input ) ||
-				input >= InfiniteScale;
+			return !IsFinite (input);
 		}
 
 		public static Vector3D InfinitySafe( Vector3D input )

--- a/code/R3/R3.Core/Math/Utils.cs
+++ b/code/R3/R3.Core/Math/Utils.cs
@@ -39,7 +39,7 @@
 
 		public static bool Equal( double d1, double d2, double threshold )
 		{
-			return Zero( d1 - d2, threshold );
+			return ((d1 >= d2 - threshold) && (d1 <= d2 + threshold)) ? true: false;
 		}
 
 		public static bool Zero( double d, double threshold )


### PR DESCRIPTION
Hi Roice, I changed some code in `infinity.cs, utils.cs and Vector3d.cs`. Nothing deleted and the calling interface remains the same, I only changed the implementation of some functions.

The first is I added a `IsFinite` method, and then use this to define `IsInfinite`. I think this approach can make the code simpler.

Then the `Equal` method in `utils.cs`. `d1 - d2 < = threshold` fails for `infinity` inputs, but a slight modification can make it work in this case. And your `compare` method in `Vector3d.cs` can also be simplified.